### PR TITLE
Add test for exit on error

### DIFF
--- a/source/sqlclUnitTest.sh
+++ b/source/sqlclUnitTest.sh
@@ -329,6 +329,8 @@ EOF
     ##  Procedural variables
     ############################################################################
     local workingDirectory
+    local sqlWheneverErrorTest
+    local liquibaseWehenverErrorTest
     local directTestResultFile
     local wrappedTestResultFile
     local liquibaseTestResultFile
@@ -534,13 +536,68 @@ EOF
 
     printf -- 'Database connection test successful!\n'
 
+    # Setup temporary directory
+    workingDirectory="$(mktemp -d)"
+
+    printf -- '\n'
+    printf -- '%s\n' "${h1}"
+    printf -- '%s %s\n' "${hs}" 'Check SQLCL Liquibase error exits SQLcl'
+    printf -- '%s\n' "${h1}"
+
+    # Setup testfiles to check `whenever sqlerror exit failure` and liquibase
+    sqlWheneverErrorTest="${workingDirectory}/wheneverError.sql"
+    liquibaseWehenverErrorTest="${workingDirectory}/wheneverError.xml"
+    touch "${sqlWheneverErrorTest}"
+    touch "${liquibaseWehenverErrorTest}"
+
+    {
+        printf -- 'whenever sqlerror exit failure\n'
+        printf -- 'set serveroutput on size unlimited\n'
+        printf -- 'set verify on\n'
+        printf -- 'set echo on\n'
+        printf -- '\n'
+        printf -- 'liquibase update -search-path %s -changelog-file %s\n' "${workingDirectory}" "$(basename "${liquibaseWehenverErrorTest}")"
+        printf -- 'exit'
+    } > "${sqlWheneverErrorTest}"
+
+    {
+        printf -- '<?xml version="1.0" encoding="UTF-8"?>\n'
+        printf -- '<databaseChangeLog\n'
+        printf -- '    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"\n'
+        printf -- '    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"\n'
+        printf -- '    xmlns:ora="http://www.oracle.com/xml/ns/dbchangelog-ext"\n'
+        printf -- '    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.17.xsd"\n'
+        printf -- '>\n'
+        printf -- '    <changeSet\n'
+        printf -- '        id="throw_error"\n'
+        printf -- '        author="jlyle"\n'
+        printf -- '        runOnChange="true"\n'
+        printf -- '        runAlways="true"\n'
+        printf -- '    >\n'
+        printf -- '        <sql endDelimiter="/">\n'
+        printf -- '            begin\n'
+        printf -- '                null;\n'
+        printf -- '                raise_application_error(-20001, '\''Cause exit'\'');\n'
+        printf -- '            end;\n'
+        printf -- '            /\n'
+        printf -- '        </sql>\n'
+        printf -- '    </changeSet>\n'
+        printf -- '</databaseChangeLog>\n'
+    } > "${liquibaseWehenverErrorTest}"
+
+    if "${sqlclBinary}" -S -L -noupdates "${sqlclConnectStringWithPassword}" @"${sqlWheneverErrorTest}" 1>/dev/null 2>&1; then
+        printf -- 'ERROR: SQLcl not exiting appropriately when Liquibase fails\n' >&2
+        return 26
+    fi
+
+    printf -- 'SQLCL Liquibase error exits SQLcl test successful!\n'
+
     printf -- '\n'
     printf -- '%s\n' "${h1}"
     printf -- '%s %s\n' "${hs}" 'Run unit tests'
     printf -- '%s\n' "${h1}"
 
-    # Setup temporary directory
-    workingDirectory="$(mktemp -d)"
+    # Setup unit test result files
     directTestResultFile="${workingDirectory}/directResults.txt"
     wrappedTestResultFile="${workingDirectory}/wrappedResults.txt"
     liquibaseTestResultFile="${workingDirectory}/liquibaseResults.txt"

--- a/source/sqlclUnitTest.sh
+++ b/source/sqlclUnitTest.sh
@@ -634,7 +634,7 @@ EOF
             testResultCodes+=("${testResultCode}")
             testResultPlainStrings+=("${testResultPlainString}")
             testResultColorizedStrings+=("${testResultColorizedString}")
-        done < <( cat "${testResultFile}" | sort )
+        done < <( sort < "${testResultFile}" )
     done
 
     # Remove all working files


### PR DESCRIPTION
The SQLcl Liquibase tests rely on SQLcl exiting when liquibase exits with an error and `whenever sqlerror exit failure` is set. This needs to be tested in order to ensure accurate results