### PR TITLE
Improvements from testing attempts

### DIFF
--- a/source/sqlclUnitTest.sh
+++ b/source/sqlclUnitTest.sh
@@ -568,7 +568,7 @@ EOF
 
     {
         printf -- 'whenever sqlerror exit failure\n'
-        printf -- 'liquibase update -search-path %s -changelog-file %s\n' "${workingDirectory}" "$(basename "${liquibaseWehenverErrorTest}")"
+        printf -- 'liquibase update -changelog-file %s\n' "$(basename "${liquibaseWehenverErrorTest}")"
         printf -- 'exit'
     } > "${sqlWheneverErrorTest}"
 
@@ -597,10 +597,14 @@ EOF
         printf -- '</databaseChangeLog>\n'
     } > "${liquibaseWehenverErrorTest}"
 
+    cd "${workingDirectory}" || return 1
     if "${sqlclBinary}" -S -L -noupdates "${sqlclConnectStringWithPassword}" @"${sqlWheneverErrorTest}" 1>/dev/null 2>&1; then
+        cd "${originalPWD}" || return 1
         printf -- 'ERROR: SQLcl not exiting appropriately on Liquibase error\n' >&2
         return 27
     fi
+    cd "${originalPWD}" || return 1
+
 
     printf -- 'Liquibase error exits SQLcl test successful!\n'
 

--- a/source/sqlcl_direct_unit_tests/sqlcl-liquibase-search-path.sql
+++ b/source/sqlcl_direct_unit_tests/sqlcl-liquibase-search-path.sql
@@ -1,0 +1,27 @@
+begin
+    for x in (
+        select *
+        from user_tables
+        where table_name = 'DATABASECHANGELOG'
+    )
+    loop
+        execute immediate 'trucate table databasechangelog';
+    end loop;
+end;
+/
+
+liquibase update -search-path &1/sqlcl-liquibase-search-path -changelog-file changelog.xml
+
+declare
+    l_count number;
+begin
+    select count(1)
+    into l_count
+    from databasechangelog
+    where id = 'sqlcl-liquibase-search-path';
+
+    if l_count = 0 then
+        raise_application_error(-20001, 'Search path not working');
+    end if;
+end;
+/

--- a/source/sqlcl_direct_unit_tests/sqlcl-liquibase-search-path.sql
+++ b/source/sqlcl_direct_unit_tests/sqlcl-liquibase-search-path.sql
@@ -5,7 +5,7 @@ begin
         where table_name = 'DATABASECHANGELOG'
     )
     loop
-        execute immediate 'trucate table databasechangelog';
+        execute immediate 'truncate table databasechangelog';
     end loop;
 end;
 /

--- a/source/sqlcl_direct_unit_tests/sqlcl-liquibase-search-path/changelog.xml
+++ b/source/sqlcl_direct_unit_tests/sqlcl-liquibase-search-path/changelog.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ora="http://www.oracle.com/xml/ns/dbchangelog-ext"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.17.xsd"
+>
+    <changeSet
+        id="sqlcl-liquibase-search-path"
+        author="jlyle"
+        runOnChange="true"
+        runAlways="true"
+    >
+        <output>Success</output>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
- Do not rely on liquibase `-search-path` parameter for testing `whenever sqlerror exit failure`
- Add basic test for liquibase `-search-path` parameter
- Log execution output in file in log folder