### PR TITLE
Add parallel execution, bash improvements, improved changelog object handling

### DIFF
--- a/source/sqlclUnitTest.sh
+++ b/source/sqlclUnitTest.sh
@@ -250,13 +250,6 @@ function main() {
 				liquibase update -contexts test_context -database-changelog-table-name ${databaseChangelogTableName} -changelog-file ${testFilename}
 				EOF
             testResultCode=$?
-
-            # "${sqlclBinary}" "${sqlParamsDirectConnect[@]}" "${sqlParamsWithPassword[@]}" 1>/dev/null 2>&1 <<- EOF
-			# 	drop view ${databaseChangelogTableName}_DETAILS;
-			# 	drop table ${databaseChangelogTableName}_ACTIONS;
-			# 	drop table ${databaseChangelogTableName};
-			# 	drop table ${databaseChangelogTableName}LOCK;
-			# 	EOF
         elif [[ "${testType}" = "${testTypeSqlclLiquibaseSearchPath}" ]]; then
             resultFile="${liquibaseSearchPathTestResultFile}"
             logFile="${logDirectory}/liquibase-search-path/${testName}.log"
@@ -275,13 +268,6 @@ function main() {
 				liquibase update -contexts test_context -database-changelog-table-name ${databaseChangelogTableName} -search-path ${testDirectory} -changelog-file ${testFilename}
 				EOF
             testResultCode=$?
-
-            # "${sqlclBinary}" "${sqlParamsDirectConnect[@]}" "${sqlParamsWithPassword[@]}" 1>/dev/null 2>&1 <<- EOF
-			# 	drop view ${databaseChangelogTableName}_DETAILS;
-			# 	drop table ${databaseChangelogTableName}_ACTIONS;
-			# 	drop table ${databaseChangelogTableName};
-			# 	drop table ${databaseChangelogTableName}LOCK;
-			# 	EOF
         fi
 
         printf -- '%s:%s\n' "${testName}" "${testResultCode}" >> "${resultFile}"

--- a/source/sqlcl_direct_unit_tests/sqlcl-liquibase-defaults-file-respected.sql
+++ b/source/sqlcl_direct_unit_tests/sqlcl-liquibase-defaults-file-respected.sql
@@ -1,1 +1,1 @@
-liquibase update -search-path / -defaults-file &1/sqlcl-liquibase-defaults-file-respected/liquibase.properties -changelog-file &1/sqlcl-liquibase-defaults-file-respected/changelog.xml
+liquibase update -database-changelog-table-name &1._changelog -search-path / -defaults-file &2/sqlcl-liquibase-defaults-file-respected/liquibase.properties -changelog-file &2/sqlcl-liquibase-defaults-file-respected/changelog.xml

--- a/source/sqlcl_direct_unit_tests/sqlcl-liquibase-do-not-prompt-password.sql
+++ b/source/sqlcl_direct_unit_tests/sqlcl-liquibase-do-not-prompt-password.sql
@@ -1,4 +1,4 @@
-liquibase update -search-path &1/sqlcl-liquibase-do-not-prompt-password -changelog-file changelog.xml
+liquibase update -database-changelog-table-name &1._changelog -search-path &2/sqlcl-liquibase-do-not-prompt-password -changelog-file changelog.xml
 
 select 'test'
 from sys.dual;

--- a/source/sqlcl_direct_unit_tests/sqlcl-liquibase-root-changelog-relative-to-cwd.sql
+++ b/source/sqlcl_direct_unit_tests/sqlcl-liquibase-root-changelog-relative-to-cwd.sql
@@ -1,3 +1,3 @@
 cd "sqlcl-liquibase-root-changelog-relative-to-cwd"
 
-liquibase update -changelog-file sqlcl-liquibase-root-changelog-relative-to-cwd-changelog.xml
+liquibase update -database-changelog-table-name &1._changelog -changelog-file sqlcl-liquibase-root-changelog-relative-to-cwd-changelog.xml

--- a/source/sqlcl_direct_unit_tests/sqlcl-liquibase-root-changelog-relative-to-script-absolute.sql
+++ b/source/sqlcl_direct_unit_tests/sqlcl-liquibase-root-changelog-relative-to-script-absolute.sql
@@ -1,1 +1,1 @@
-@ "&1/sqlcl-liquibase-root-changelog-relative-to-script-absolute/sqlcl-liquibase-root-changelog-relative-to-script-absolute-sql.sql"
+@ "&2/sqlcl-liquibase-root-changelog-relative-to-script-absolute/sqlcl-liquibase-root-changelog-relative-to-script-absolute-sql.sql"

--- a/source/sqlcl_direct_unit_tests/sqlcl-liquibase-root-changelog-relative-to-script-absolute/sqlcl-liquibase-root-changelog-relative-to-script-absolute-sql.sql
+++ b/source/sqlcl_direct_unit_tests/sqlcl-liquibase-root-changelog-relative-to-script-absolute/sqlcl-liquibase-root-changelog-relative-to-script-absolute-sql.sql
@@ -1,1 +1,1 @@
-liquibase update -changelog-file sqlcl-liquibase-root-changelog-relative-to-script-absolute-changelog.xml
+liquibase update -database-changelog-table-name &1._changelog -changelog-file sqlcl-liquibase-root-changelog-relative-to-script-absolute-changelog.xml

--- a/source/sqlcl_direct_unit_tests/sqlcl-liquibase-root-changelog-relative-to-script-relative/sqlcl-liquibase-root-changelog-relative-to-script-relative-sql.sql
+++ b/source/sqlcl_direct_unit_tests/sqlcl-liquibase-root-changelog-relative-to-script-relative/sqlcl-liquibase-root-changelog-relative-to-script-relative-sql.sql
@@ -1,1 +1,1 @@
-liquibase update -changelog-file sqlcl-liquibase-root-changelog-relative-to-script-relative-changelog.xml
+liquibase update -database-changelog-table-name &1._changelog -changelog-file sqlcl-liquibase-root-changelog-relative-to-script-relative-changelog.xml

--- a/source/sqlcl_direct_unit_tests/sqlcl-liquibase-runApexScript-basic.sql
+++ b/source/sqlcl_direct_unit_tests/sqlcl-liquibase-runApexScript-basic.sql
@@ -1,1 +1,1 @@
-liquibase update -changelog-file sqlcl-liquibase-runApexScript-basic/changelog.xml
+liquibase update -database-changelog-table-name &1._changelog -changelog-file sqlcl-liquibase-runApexScript-basic/changelog.xml

--- a/source/sqlcl_direct_unit_tests/sqlcl-liquibase-runApexScript-heirarchical.sql
+++ b/source/sqlcl_direct_unit_tests/sqlcl-liquibase-runApexScript-heirarchical.sql
@@ -1,1 +1,1 @@
-liquibase update -changelog-file sqlcl-liquibase-runApexScript-heirarchical/changelog.xml
+liquibase update -database-changelog-table-name &1._changelog -changelog-file sqlcl-liquibase-runApexScript-heirarchical/changelog.xml

--- a/source/sqlcl_direct_unit_tests/sqlcl-liquibase-runOracleScript-basic.sql
+++ b/source/sqlcl_direct_unit_tests/sqlcl-liquibase-runOracleScript-basic.sql
@@ -1,1 +1,1 @@
-liquibase update -changelog-file sqlcl-liquibase-runApexScript-basic/changelog.xml
+liquibase update -database-changelog-table-name &1._changelog -changelog-file sqlcl-liquibase-runApexScript-basic/changelog.xml

--- a/source/sqlcl_direct_unit_tests/sqlcl-liquibase-runOracleScript-heirarchical.sql
+++ b/source/sqlcl_direct_unit_tests/sqlcl-liquibase-runOracleScript-heirarchical.sql
@@ -1,1 +1,1 @@
-liquibase update -changelog-file sqlcl-liquibase-runApexScript-heirarchical/changelog.xml
+liquibase update -database-changelog-table-name &1._changelog -changelog-file sqlcl-liquibase-runApexScript-heirarchical/changelog.xml

--- a/source/sqlcl_direct_unit_tests/sqlcl-liquibase-search-path.sql
+++ b/source/sqlcl_direct_unit_tests/sqlcl-liquibase-search-path.sql
@@ -10,15 +10,16 @@ begin
 end;
 /
 
-liquibase update -search-path &1/sqlcl-liquibase-search-path -changelog-file changelog.xml
+liquibase update -database-changelog-table-name &1._changelog -search-path &2/sqlcl-liquibase-search-path -changelog-file changelog.xml
 
 declare
     l_count number;
 begin
-    select count(1)
-    into l_count
-    from databasechangelog
-    where id = 'sqlcl-liquibase-search-path';
+    execute immediate
+        q'[select count(1)]' || ' ' ||
+        q'[from &1._changelog]' || ' ' ||
+        q'[where id = 'sqlcl-liquibase-search-path']'
+    into l_count;
 
     if l_count = 0 then
         raise_application_error(-20001, 'Search path not working');


### PR DESCRIPTION
- Add parallelization control parameter, default to executing tests in a single test type in parallel (test types in serial)
- Never run anything against DATABASECHANGELOG, always used custom changelog
- Cleanup all changelog objects after all tests complete
- Update `find` command used to collect test cases to be POSIX compatible