### PR TITLE
Sqlcl 24.1.0 additions

### DIFF
--- a/source/sqlcl_direct_unit_tests/sqlcl-liquibase-default-file-relative-to-script-absolute.sql
+++ b/source/sqlcl_direct_unit_tests/sqlcl-liquibase-default-file-relative-to-script-absolute.sql
@@ -1,0 +1,1 @@
+@ "&2/sqlcl-liquibase-default-file-relative-to-script-absolute/script.sql"

--- a/source/sqlcl_direct_unit_tests/sqlcl-liquibase-default-file-relative-to-script-absolute/changelog.xml
+++ b/source/sqlcl_direct_unit_tests/sqlcl-liquibase-default-file-relative-to-script-absolute/changelog.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ora="http://www.oracle.com/xml/ns/dbchangelog-ext"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.17.xsd"
+>
+    <changeSet
+        id="something"
+        author="jlyle"
+        runOnChange="true"
+        runAlways="true"
+    >
+        <output>Run successfully!</output>
+    </changeSet>
+</databaseChangeLog>

--- a/source/sqlcl_direct_unit_tests/sqlcl-liquibase-default-file-relative-to-script-absolute/liquibase.properties
+++ b/source/sqlcl_direct_unit_tests/sqlcl-liquibase-default-file-relative-to-script-absolute/liquibase.properties
@@ -1,0 +1,1 @@
+liquibase.command.contexts=runme

--- a/source/sqlcl_direct_unit_tests/sqlcl-liquibase-default-file-relative-to-script-absolute/script.sql
+++ b/source/sqlcl_direct_unit_tests/sqlcl-liquibase-default-file-relative-to-script-absolute/script.sql
@@ -1,0 +1,19 @@
+-- Make sure the liquibase changelog table exists
+liquibase validate -database-changelog-table-name &1._changelog -changelog-file changelog.xml
+
+-- Call to see if functionality works
+liquibase update -database-changelog-table-name &1._changelog -changelog-file changelog.xml -defaults-file liquibase.properties
+
+-- See if any changesets were run
+declare
+    c_table_name    constant    varchar2(255 char)  :=  '&1._changelog';
+    l_count                     number;
+begin
+    execute immediate 'select count(1) from ' || c_table_name
+    into l_count;
+
+    if l_count = 0 then
+        raise_application_error(-20001, 'Liquibase update did not run');
+    end if;
+end;
+/

--- a/source/sqlcl_direct_unit_tests/sqlcl-liquibase-default-file-relative-to-script-relative.sql
+++ b/source/sqlcl_direct_unit_tests/sqlcl-liquibase-default-file-relative-to-script-relative.sql
@@ -1,0 +1,1 @@
+@ "sqlcl-liquibase-default-file-relative-to-script-relative/script.sql"

--- a/source/sqlcl_direct_unit_tests/sqlcl-liquibase-default-file-relative-to-script-relative/changelog.xml
+++ b/source/sqlcl_direct_unit_tests/sqlcl-liquibase-default-file-relative-to-script-relative/changelog.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ora="http://www.oracle.com/xml/ns/dbchangelog-ext"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.17.xsd"
+>
+    <changeSet
+        id="something"
+        author="jlyle"
+        runOnChange="true"
+        runAlways="true"
+    >
+        <output>Run successfully!</output>
+    </changeSet>
+</databaseChangeLog>

--- a/source/sqlcl_direct_unit_tests/sqlcl-liquibase-default-file-relative-to-script-relative/liquibase.properties
+++ b/source/sqlcl_direct_unit_tests/sqlcl-liquibase-default-file-relative-to-script-relative/liquibase.properties
@@ -1,0 +1,1 @@
+liquibase.command.contexts=runme

--- a/source/sqlcl_direct_unit_tests/sqlcl-liquibase-default-file-relative-to-script-relative/script.sql
+++ b/source/sqlcl_direct_unit_tests/sqlcl-liquibase-default-file-relative-to-script-relative/script.sql
@@ -1,0 +1,19 @@
+-- Make sure the liquibase changelog table exists
+liquibase validate -database-changelog-table-name &1._changelog -changelog-file changelog.xml
+
+-- Call to see if functionality works
+liquibase update -database-changelog-table-name &1._changelog -changelog-file changelog.xml -defaults-file liquibase.properties
+
+-- See if any changesets were run
+declare
+    c_table_name    constant    varchar2(255 char)  :=  '&1._changelog';
+    l_count                     number;
+begin
+    execute immediate 'select count(1) from ' || c_table_name
+    into l_count;
+
+    if l_count = 0 then
+        raise_application_error(-20001, 'Liquibase update did not run');
+    end if;
+end;
+/

--- a/source/sqlcl_direct_unit_tests/sqlcl-liquibase-defaults-file-respected/changelog.xml
+++ b/source/sqlcl_direct_unit_tests/sqlcl-liquibase-defaults-file-respected/changelog.xml
@@ -6,21 +6,27 @@
     xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.17.xsd"
 >
     <changeSet
+        id="test_1"
         author="jlyle"
-        id="test1"
         runOnChange="true"
         runAlways="true"
+        context="foo"
     >
-        <sql>select 1 from sys.dual;</sql>
+        <sql endDelimiter="/">
+            begin
+                raise_application_error(-20001, 'SHOULD NOT HAVE RUN');
+            end;
+            /
+        </sql>
     </changeSet>
 
-    <!-- Identical changeset identifier needed to test defaults file -->
     <changeSet
+        id="test_2"
         author="jlyle"
-        id="test1"
         runOnChange="true"
         runAlways="true"
+        context="runme"
     >
-        <sql>select 1 from sys.dual;</sql>
+        <output>Should run</output>
     </changeSet>
 </databaseChangeLog>

--- a/source/sqlcl_direct_unit_tests/sqlcl-liquibase-defaults-file-respected/liquibase.properties
+++ b/source/sqlcl_direct_unit_tests/sqlcl-liquibase-defaults-file-respected/liquibase.properties
@@ -1,1 +1,1 @@
-liquibase.allowDuplicatedChangesetIdentifiers=true
+liquibase.command.contexts=runme


### PR DESCRIPTION
- Update unit test checking if the `-defaults-file` respects liquibase configuration settings so that it works with 24.1.0+
- Add new unit tests checking if the `-defaults-file` can be found relative to the script containing the `liquibase update` command