### PR TITLE
SQLcl 24.4.1+ additions

### DIFF
--- a/source/lb_unit_tests/default-sqlcl-executor.xml
+++ b/source/lb_unit_tests/default-sqlcl-executor.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ora="http://www.oracle.com/xml/ns/dbchangelog-ext"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.17.xsd"
+>
+    <changeSet
+        id="default-sqlcl-executor-test"
+        author="jyle"
+        runOnChange="true"
+        runAlways="true"
+    >
+    <sql>prompt "Hello world!"</sql>
+    </changeSet>
+</databaseChangeLog>

--- a/source/lb_unit_tests/set-define-persists-accross-changesets.xml
+++ b/source/lb_unit_tests/set-define-persists-accross-changesets.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ora="http://www.oracle.com/xml/ns/dbchangelog-ext"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.17.xsd"
+>
+    <changeSet
+        id="setup-environment"
+        author="jlyle"
+        runOnChange="true"
+        runAlways="true"
+    >
+        <sql>set define off</sql>
+    </changeSet>
+    <changeSet
+        id="test-define"
+        author="jlyle"
+        runOnChange="true"
+        runAlways="true"
+    >
+        <sql><![CDATA[select '&foo' from sys.dual;]]></sql>
+    </changeSet>
+</databaseChangeLog>

--- a/source/lb_unit_tests/set-sqlblanklines-persists-accross-changesets.xml
+++ b/source/lb_unit_tests/set-sqlblanklines-persists-accross-changesets.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ora="http://www.oracle.com/xml/ns/dbchangelog-ext"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.17.xsd"
+>
+    <changeSet
+        id="setup-environment"
+        author="jlyle"
+        runOnChange="true"
+        runAlways="true"
+    >
+        <sql>set sqlblanklines on</sql>
+    </changeSet>
+    <changeSet
+        id="test-sqlblanklines"
+        author="jlyle"
+        runOnChange="true"
+        runAlways="true"
+    >
+        <sql>select
+
+        'foo'
+
+        from
+
+        sys.dual;</sql>
+    </changeSet>
+</databaseChangeLog>

--- a/source/lb_unit_tests/warnings-should-not-exit.xml
+++ b/source/lb_unit_tests/warnings-should-not-exit.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ora="http://www.oracle.com/xml/ns/dbchangelog-ext"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.17.xsd"
+>
+    <include file="warnings-should-not-exit/ct.sql" relativeToChangelogFile="true" />
+    <include file="warnings-should-not-exit/ot.sql" relativeToChangelogFile="true" />
+    <include file="warnings-should-not-exit/reset.sql" relativeToChangelogFile="true" />
+</databaseChangeLog>

--- a/source/lb_unit_tests/warnings-should-not-exit/ct.sql
+++ b/source/lb_unit_tests/warnings-should-not-exit/ct.sql
@@ -1,0 +1,9 @@
+--liquibase formatted sql
+
+--changeset jlyle:collection_type_create stripComments:false endDelimiter:/ runOnChange:true
+create or replace type jml_test_ct
+    force
+    is table
+    of jml_test_ot;
+/
+--rollback drop type jml_test_ct force;

--- a/source/lb_unit_tests/warnings-should-not-exit/ot.sql
+++ b/source/lb_unit_tests/warnings-should-not-exit/ot.sql
@@ -1,0 +1,13 @@
+--liquibase formatted sql
+
+--changeset jlyle:object_type_create stripComments:false endDelimiter:/ runOnChange:true
+create or replace type jml_test_ot
+    force
+    authid definer
+    is object(
+        seq             number,
+        key_string      varchar2(32767),
+        value_string    varchar2(32767)
+    );
+/
+--rollback drop type jml_test_ot force;

--- a/source/lb_unit_tests/warnings-should-not-exit/reset.sql
+++ b/source/lb_unit_tests/warnings-should-not-exit/reset.sql
@@ -1,0 +1,20 @@
+--liquibase formatted sql
+
+--changeset jlyle:object_type_drop stripComments:false endDelimiter:/ runOnChange:true
+begin
+
+    begin
+        execute immediate 'drop type jml_test_ct';
+    exception when others then
+        null;
+    end;
+
+    begin
+        execute immediate 'drop type jml_test_ot';
+    exception when others then
+        null;
+    end;
+
+end;
+/
+--rollback not required

--- a/source/sqlclUnitTest.sh
+++ b/source/sqlclUnitTest.sh
@@ -828,6 +828,19 @@ function main() {
     fi
 
     ##
+    ## Cleanup liquibase error log files
+    ##
+
+    printf -- '\n' | tee -a "${logMainFile}"
+    printf -- '%s\n' "${h1}" | tee -a "${logMainFile}"
+    printf -- '%s %s\n' "${hs}" 'Cleanup liquibase error log files' | tee -a "${logMainFile}"
+    printf -- '%s\n' "${h1}" | tee -a "${logMainFile}"
+
+    find "${liquibaseTestsDirectory}" -iname 'sqlcl-lb-error*.log' -delete
+
+    printf -- 'Completed.\n' | tee -a "${logMainFile}"
+
+    ##
     ## Cleanup testing objects in database
     ##
 
@@ -836,7 +849,7 @@ function main() {
     printf -- '%s %s\n' "${hs}" 'Cleanup unit test database objects' | tee -a "${logMainFile}"
     printf -- '%s\n' "${h1}" | tee -a "${logMainFile}"
 
-    "${sqlclBinary}" "${sqlParamsDirectConnect[@]}" "${sqlParamsWithPassword[@]}" 1>>"${logMainFile}" 2>&1 <<- EOF
+    SQLPATH="" "${sqlclBinary}" "${sqlParamsDirectConnect[@]}" "${sqlParamsWithPassword[@]}" 1>>"${logMainFile}" 2>&1 <<- EOF
 		declare
 			c_unique_identifier constant    varchar2(255 char)  := upper('${scriptUniqueIdentifier}');
 		begin


### PR DESCRIPTION
- Make sure SQLcl executor is being used by default for liquibase (new test)
- Make sure "set define" calls persist across changelogs (new test)
- Make sure "set sqlblanklines" calls persist across changelogs (new test)
- Make sure PL/SQL warnings do not cause liquibase to exit (new test)
- Cleanup liquibase error log files created from failing liquibase tests
- Unset SQLPATH environment variable before cleaning up unit test database object